### PR TITLE
Add home and shell to User struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,11 +155,11 @@ struct c_passwd {
     pub pw_passwd:  *const c_char,
     pub pw_uid:     uid_t,          // user ID
     pub pw_gid:     gid_t,          // group ID
-    pub pw_change:  time_t,
-    pub pw_class:   *const c_char,
     pub pw_gecos:   *const c_char,  // full name
     pub pw_dir:     *const c_char,  // login dir
     pub pw_shell:   *const c_char,  // login shell
+    pub pw_change:  time_t,
+    pub pw_class:   *const c_char,
     pub pw_expire:  time_t,         // password expiry time
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,6 +193,12 @@ pub struct User {
 
     /// The ID of this user's primary group
     pub primary_group: gid_t,
+
+    /// This user's home directory
+    pub home_dir: String,
+
+    /// This user's shell
+    pub shell: String,
 }
 
 /// Information about a particular group.
@@ -228,7 +234,13 @@ unsafe fn from_raw_buf(p: *const i8) -> String {
 unsafe fn passwd_to_user(pointer: *const c_passwd) -> Option<User> {
     if !pointer.is_null() {
         let pw = read(pointer);
-        Some(User { uid: pw.pw_uid as uid_t, name: from_raw_buf(pw.pw_name as *const i8), primary_group: pw.pw_gid as gid_t })
+        Some(User {
+            uid: pw.pw_uid as uid_t,
+            name: from_raw_buf(pw.pw_name as *const i8),
+            primary_group: pw.pw_gid as gid_t,
+            home_dir: from_raw_buf(pw.pw_dir as *const i8),
+            shell: from_raw_buf(pw.pw_shell as *const i8)
+        })
     }
     else {
         None
@@ -456,5 +468,15 @@ mod test {
         let user = users.get_user_by_uid(uid).unwrap();
         let user2 = users.get_user_by_uid(user.uid).unwrap();
         assert_eq!(user2.uid, uid);
+    }
+
+    #[test]
+    fn user_info() {
+        let mut users = OSUsers::empty_cache();
+        let uid = users.get_current_uid();
+        let user = users.get_user_by_uid(uid).unwrap();
+        // Not a real test but can be used to verify correct results
+        // Use with --nocapture on test executable to show output
+        println!("HOME={}, SHELL={}", user.home_dir, user.shell);
     }
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -19,7 +19,7 @@
 //! ```
 //! use users::mock::{MockUsers, User, Group};
 //! let mut users = MockUsers::with_current_uid(1000);
-//! users.add_user(User { uid: 1000, name: "Bobbins".to_string(), primary_group: 100 });
+//! users.add_user(User { uid: 1000, name: "Bobbins".to_string(), primary_group: 100, home_dir: "/home/bobbins".to_string(), shell: "/bin/bash".to_string() });
 //! users.add_group(Group { gid: 100, name: "funkyppl".to_string(), members: vec![ "other_person".to_string() ] });
 //! ```
 //!
@@ -43,7 +43,7 @@
 //! }
 //!
 //! let mut users = MockUsers::with_current_uid(1001);
-//! users.add_user(User { uid: 1001, name: "fred".to_string(), primary_group: 101 });
+//! users.add_user(User { uid: 1001, name: "fred".to_string(), primary_group: 101 , home_dir: "/home/fred".to_string(), shell: "/bin/bash".to_string()});
 //! print_current_username(&mut users);
 //!
 //! let mut actual_users = OSUsers::empty_cache();
@@ -115,7 +115,7 @@ mod test {
     #[test]
     fn current_username() {
         let mut users = MockUsers::with_current_uid(1337);
-        users.add_user(User { uid: 1337, name: "fred".to_string(), primary_group: 101 });
+        users.add_user(User { uid: 1337, name: "fred".to_string(), primary_group: 101, home_dir: "/home/fred".to_string(), shell: "/bin/bash".to_string() });
         assert_eq!(Some("fred".to_string()), users.get_current_username())
     }
 
@@ -128,21 +128,21 @@ mod test {
     #[test]
     fn uid() {
         let mut users = MockUsers::with_current_uid(0);
-        users.add_user(User { uid: 1337, name: "fred".to_string(), primary_group: 101 });
+        users.add_user(User { uid: 1337, name: "fred".to_string(), primary_group: 101, home_dir: "/home/fred".to_string(), shell: "/bin/bash".to_string() });
         assert_eq!(Some("fred".to_string()), users.get_user_by_uid(1337).map(|u| u.name))
     }
 
     #[test]
     fn username() {
         let mut users = MockUsers::with_current_uid(1337);
-        users.add_user(User { uid: 1440, name: "fred".to_string(), primary_group: 101 });
+        users.add_user(User { uid: 1440, name: "fred".to_string(), primary_group: 101, home_dir: "/home/fred".to_string(), shell: "/bin/bash".to_string() });
         assert_eq!(Some(1440), users.get_user_by_name("fred").map(|u| u.uid))
     }
 
     #[test]
     fn no_username() {
         let mut users = MockUsers::with_current_uid(1337);
-        users.add_user(User { uid: 1440, name: "fred".to_string(), primary_group: 101 });
+        users.add_user(User { uid: 1440, name: "fred".to_string(), primary_group: 101, home_dir: "/home/fred".to_string(), shell: "/bin/bash".to_string() });
         assert_eq!(None, users.get_user_by_name("criminy").map(|u| u.uid))
     }
 


### PR DESCRIPTION
As mentioned in #3 this PR adds `home_dir` and `shell` to the `User` struct and also fixed the memory layout of the FFI struct `c_passwd` (at least for (Arch)Linux).
