### PR TITLE
set effective gid before setting effective uid in `switch_user_group`

### DIFF
--- a/src/switch.rs
+++ b/src/switch.rs
@@ -139,7 +139,7 @@ pub fn switch_user_group(uid: uid_t, gid: gid_t) -> IOResult<SwitchUserGuard> {
         gid: get_effective_gid(),
     };
 
-    try!(set_effective_uid(uid));
     try!(set_effective_gid(gid));
+    try!(set_effective_uid(uid));
     Ok(current_state)
 }


### PR DESCRIPTION
When I run a program using `switch_user_group` as root (uid 0/gid 0) and try and switch to another user that doesn't have setgid privileges (uid 1000/gid 1000 in this case), it fails with `Operation not permitted (os error 1)`. I called the functions manually and found that `set_effective_gid` fails if called after `set_effective_uid`, but it works fine if called the other way around. This patch fixes the problem for me. 

My guess is that `setegid` checks your effective uid to see if you have permission to change your effective gid, and since it was just changed to a non-privileged effective uid, the call fails. 