### PR TITLE
Added support for Redox

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,3 @@
+[target.x86_64-unknown-redox]
+linker = "x86_64-unknown-redox-gcc"
+rustflags = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,7 @@ version = "0.6.0"
 
 [dependencies]
 libc = "0.2"
+
+[target.'cfg(target_os = "redox")'.dependencies]
+redox_syscall = "0.1"
+redox_users = { "git" = "https://github.com/redox-os/users.git" }

--- a/examples/os.rs
+++ b/examples/os.rs
@@ -1,6 +1,12 @@
 extern crate users;
 use users::{Users, Groups, UsersCache};
+
+#[cfg(unix)]
 use users::os::unix::{UserExt, GroupExt};
+
+#[cfg(target_os = "redox")]
+use users::os::redox::{UserExt, GroupExt};
+
 //use users::os::bsd::UserExt as BSDUserExt;
 
 fn main() {
@@ -16,8 +22,8 @@ fn main() {
 
     // The two fields below are only available on BSD systems.
     // Linux systems don’t have the fields in their `passwd` structs!
-    //println!("Your password change timestamp is {}", you.password_change_time());
-    //println!("Your password expiry timestamp is {}", you.password_expire_time());
+	//println!("Your password change timestamp is {}", you.password_change_time());
+	//println!("Your password expiry timestamp is {}", you.password_expire_time());
 
 	let primary_group = cache.get_group_by_gid(you.primary_group_id()).expect("No entry for your primary group!");
 	println!("Your primary group has ID {} and name {}", primary_group.gid(), primary_group.name());

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -1,111 +1,50 @@
-//! Integration with the C library’s users and groups.
-//!
-//! This module uses `extern` functions and types from `libc` that integrate
-//! with the system’s C library, which integrates with the OS itself to get user
-//! and group information. It’s where the “core” user handling is done.
-//!
-//!
-//! ## Name encoding rules
-//!
-//! Under Unix, usernames and group names are considered to be
-//! null-terminated, UTF-8 strings. These are `CString`s in Rust, although in
-//! this library, they are just `String` values. Why?
-//!
-//! The reason is that any user or group values with invalid `CString` data
-//! can instead just be assumed to not exist:
-//!
-//! - If you try to search for a user with a null character in their name,
-//!   such a user could not exist anyway—so it’s OK to return `None`.
-//! - If the OS returns user information with a null character in a field,
-//!   then that field will just be truncated instead, which is valid behaviour
-//!   for a `CString`.
-//!
-//! The downside is that we use `from_utf8_lossy` instead, which has a small
-//! runtime penalty when it calculates and scans the length of the string for
-//! invalid characters. However, this should not be a problem when dealing with
-//! usernames of a few bytes each.
-//!
-//! In short, if you want to check for null characters in user fields, your
-//! best bet is to check for them yourself before passing strings into any
-//! functions.
+#[cfg(target_os = "redox")]
+pub mod redox;
+#[cfg(unix)]
+pub mod unix;
 
+#[cfg(unix)]
+pub use self::unix::{get_user_by_uid, get_user_by_name};
+#[cfg(unix)]
+pub use self::unix::{get_group_by_gid, get_group_by_name};
+#[cfg(unix)]
+pub use self::unix::{get_current_uid, get_current_username};
+#[cfg(unix)]
+pub use self::unix::{get_effective_uid, get_effective_username};
+#[cfg(unix)]
+pub use self::unix::{get_current_gid, get_current_groupname};
+#[cfg(unix)]
+pub use self::unix::{get_effective_gid, get_effective_groupname};
+#[cfg(unix)]
+pub use self::unix::AllUsers;
 
-#![allow(missing_copy_implementations)]  // for the C structs
+#[cfg(target_os = "redox")]
+pub use self::redox::{get_user_by_uid, get_user_by_name};
+#[cfg(target_os = "redox")]
+pub use self::redox::{get_group_by_gid, get_group_by_name};
+#[cfg(target_os = "redox")]
+pub use self::redox::{get_current_uid, get_current_username};
+#[cfg(target_os = "redox")]
+pub use self::redox::{get_effective_uid, get_effective_username};
+#[cfg(target_os = "redox")]
+pub use self::redox::{get_current_gid, get_current_groupname};
+#[cfg(target_os = "redox")]
+pub use self::redox::{get_effective_gid, get_effective_groupname};
+#[cfg(target_os = "redox")]
+pub use self::redox::AllUsers;
 
-use std::ffi::{CStr, CString};
 use std::fmt;
-use std::ptr::read;
+use std::path::Path;
 use std::sync::Arc;
 
 use libc::{uid_t, gid_t};
 
-#[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd"))]
-use libc::{c_char, time_t};
-
-#[cfg(target_os = "linux")]
-use libc::c_char;
-
-
-#[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd"))]
-#[repr(C)]
-pub struct c_passwd {
-    pw_name:    *const c_char,  // user name
-    pw_passwd:  *const c_char,  // password field
-    pw_uid:     uid_t,          // user ID
-    pw_gid:     gid_t,          // group ID
-    pw_change:  time_t,         // password change time
-    pw_class:   *const c_char,
-    pw_gecos:   *const c_char,
-    pw_dir:     *const c_char,  // user's home directory
-    pw_shell:   *const c_char,  // user's shell
-    pw_expire:  time_t,         // password expiry time
-}
-
-#[cfg(target_os = "linux")]
-#[repr(C)]
-pub struct c_passwd {
-    pw_name:    *const c_char,  // user name
-    pw_passwd:  *const c_char,  // password field
-    pw_uid:     uid_t,          // user ID
-    pw_gid:     gid_t,          // group ID
-    pw_gecos:   *const c_char,
-    pw_dir:     *const c_char,  // user's home directory
-    pw_shell:   *const c_char,  // user's shell
-}
-
-#[repr(C)]
-pub struct c_group {
-    gr_name:   *const c_char,         // group name
-    gr_passwd: *const c_char,         // password
-    gr_gid:    gid_t,                 // group id
-    gr_mem:    *const *const c_char,  // names of users in the group
-}
-
-extern {
-    fn getpwuid(uid: uid_t) -> *const c_passwd;
-    fn getpwnam(user_name: *const c_char) -> *const c_passwd;
-
-    fn getgrgid(gid: gid_t) -> *const c_group;
-    fn getgrnam(group_name: *const c_char) -> *const c_group;
-
-    fn getuid() -> uid_t;
-    fn geteuid() -> uid_t;
-
-    fn getgid() -> gid_t;
-    fn getegid() -> gid_t;
-
-    fn setpwent();
-    fn getpwent() -> *const c_passwd;
-    fn endpwent();
-}
-
-
 /// Information about a particular user.
 #[derive(Clone)]
 pub struct User {
-    uid: uid_t,
-    primary_group: gid_t,
-    extras: os::UserExtras,
+    pub(crate) uid: uid_t,
+    pub(crate) primary_group: gid_t,
+    pub(crate) extras: super::os::UserExtras,
 
     /// This user’s name, as an owned `String` possibly shared with a cache.
     /// Prefer using the `name()` accessor to using this field, if possible.
@@ -124,7 +63,7 @@ impl User {
             uid: uid,
             name_arc: Arc::new(name.to_owned()),
             primary_group: primary_group,
-            extras: os::UserExtras::default(),
+            extras: super::os::UserExtras::default(),
         }
     }
 
@@ -160,12 +99,11 @@ impl fmt::Debug for User {
     }
 }
 
-
 /// Information about a particular group.
 #[derive(Clone)]
 pub struct Group {
-    gid: gid_t,
-    extras: os::GroupExtras,
+    pub(crate) gid: gid_t,
+    pub(crate) extras: super::os::GroupExtras,
 
     /// This group’s name, as an owned `String` possibly shared with a cache.
     /// Prefer using the `name()` accessor to using this field, if possible.
@@ -183,7 +121,7 @@ impl Group {
         Group {
             gid: gid,
             name_arc: Arc::new(String::from(name)),
-            extras: os::GroupExtras::default(),
+            extras: super::os::GroupExtras::default(),
         }
     }
 
@@ -213,234 +151,36 @@ impl fmt::Debug for Group {
     }
 }
 
+pub trait UserExt {
+    /// Returns a path to this user’s home directory.
+    fn home_dir(&self) -> &Path;
 
-/// Reads data from a `*char` field in `c_passwd` or `g_group` into a UTF-8
-/// `String` for use in a user or group value.
-///
-/// Although `from_utf8_lossy` returns a clone-on-write string, we immediately
-/// clone it anyway: the underlying buffer is managed by the C library, not by
-/// us, so we *need* to move data out of it before the next user gets read.
-unsafe fn from_raw_buf(p: *const c_char) -> String {
-    CStr::from_ptr(p).to_string_lossy().into_owned()
+    /// Sets this user value’s home directory to the given string.
+    /// Can be used to construct test users, which by default come with a
+    /// dummy home directory string.
+    fn with_home_dir(self, home_dir: &str) -> Self;
+
+    /// Returns a path to this user’s shell.
+    fn shell(&self) -> &Path;
+
+    /// Sets this user’s shell path to the given string.
+    /// Can be used to construct test users, which by default come with a
+    /// dummy shell field.
+    fn with_shell(self, shell: &str) -> Self;
+
+    // TODO(ogham): Isn’t it weird that the setters take string slices, but
+    // the getters return paths?
 }
 
-/// Converts a raw pointer, which could be null, into a safe reference that
-/// might be `None` instead.
-///
-/// This is basically the unstable `ptr_as_ref` feature:
-/// https://github.com/rust-lang/rust/issues/27780
-/// When that stabilises, this can be replaced.
-unsafe fn ptr_as_ref<T>(pointer: *const T) -> Option<T> {
-    if pointer.is_null() {
-        None
-    }
-    else {
-        Some(read(pointer))
-    }
+pub trait GroupExt {
+
+    /// Returns a slice of the list of users that are in this group as
+    /// their non-primary group.
+    fn members(&self) -> &[String];
+
+    /// Adds a new member to this group.
+    fn add_member(self, name: &str) -> Self;
 }
-
-unsafe fn passwd_to_user(pointer: *const c_passwd) -> Option<User> {
-    if let Some(passwd) = ptr_as_ref(pointer) {
-        let name = Arc::new(from_raw_buf(passwd.pw_name));
-
-        Some(User {
-            uid:           passwd.pw_uid,
-            name_arc:      name,
-            primary_group: passwd.pw_gid,
-            extras:        os::UserExtras::from_passwd(passwd),
-        })
-    }
-    else {
-        None
-    }
-}
-
-unsafe fn struct_to_group(pointer: *const c_group) -> Option<Group> {
-    if let Some(group) = ptr_as_ref(pointer) {
-        let name = Arc::new(from_raw_buf(group.gr_name));
-
-        Some(Group {
-            gid:       group.gr_gid,
-            name_arc:  name,
-            extras:    os::GroupExtras::from_struct(group),
-        })
-    }
-    else {
-        None
-    }
-}
-
-/// Expand a list of group members to a vector of strings.
-///
-/// The list of members is, in true C fashion, a pointer to a pointer of
-/// characters, terminated by a null pointer. We check `members[0]`, then
-/// `members[1]`, and so on, until that null pointer is reached. It doesn't
-/// specify whether we should expect a null pointer or a pointer to a null
-/// pointer, so we check for both here!
-unsafe fn members(groups: *const *const c_char) -> Vec<String> {
-    let mut members = Vec::new();
-
-    for i in 0.. {
-        let username = groups.offset(i);
-
-        if username.is_null() || (*username).is_null() {
-            break;
-        }
-        else {
-            members.push(from_raw_buf(*username));
-        }
-    }
-
-    members
-}
-
-
-/// Searches for a `User` with the given ID in the system’s user database.
-/// Returns it if one is found, otherwise returns `None`.
-pub fn get_user_by_uid(uid: uid_t) -> Option<User> {
-    unsafe {
-        let passwd = getpwuid(uid);
-        passwd_to_user(passwd)
-    }
-}
-
-/// Searches for a `User` with the given username in the system’s user database.
-/// Returns it if one is found, otherwise returns `None`.
-pub fn get_user_by_name(username: &str) -> Option<User> {
-    if let Ok(username) = CString::new(username) {
-        unsafe {
-            let passwd = getpwnam(username.as_ptr());
-            passwd_to_user(passwd)
-        }
-    }
-    else {
-        // The username that was passed in contained a null character.
-        // This will *never* find anything, so just return `None`.
-        // (I can’t figure out a pleasant way to signal an error here)
-        None
-    }
-}
-
-/// Searches for a `Group` with the given ID in the system’s group database.
-/// Returns it if one is found, otherwise returns `None`.
-pub fn get_group_by_gid(gid: gid_t) -> Option<Group> {
-    unsafe {
-        let group = getgrgid(gid);
-        struct_to_group(group)
-    }
-}
-
-/// Searches for a `Group` with the given group name in the system’s group database.
-/// Returns it if one is found, otherwise returns `None`.
-pub fn get_group_by_name(group_name: &str) -> Option<Group> {
-    if let Ok(group_name) = CString::new(group_name) {
-        unsafe {
-            let group = getgrnam(group_name.as_ptr());
-            struct_to_group(group)
-        }
-    }
-    else {
-        // The group name that was passed in contained a null character.
-        // This will *never* find anything, so just return `None`.
-        // (I can’t figure out a pleasant way to signal an error here)
-        None
-    }
-}
-
-/// Returns the user ID for the user running the process.
-pub fn get_current_uid() -> uid_t {
-    unsafe { getuid() }
-}
-
-/// Returns the username of the user running the process.
-pub fn get_current_username() -> Option<String> {
-    let uid = get_current_uid();
-    get_user_by_uid(uid).map(|u| Arc::try_unwrap(u.name_arc).unwrap())
-}
-
-/// Returns the user ID for the effective user running the process.
-pub fn get_effective_uid() -> uid_t {
-    unsafe { geteuid() }
-}
-
-/// Returns the username of the effective user running the process.
-pub fn get_effective_username() -> Option<String> {
-    let uid = get_effective_uid();
-    get_user_by_uid(uid).map(|u| Arc::try_unwrap(u.name_arc).unwrap())
-}
-
-/// Returns the group ID for the user running the process.
-pub fn get_current_gid() -> gid_t {
-    unsafe { getgid() }
-}
-
-/// Returns the groupname of the user running the process.
-pub fn get_current_groupname() -> Option<String> {
-    let gid = get_current_gid();
-    get_group_by_gid(gid).map(|g| Arc::try_unwrap(g.name_arc).unwrap())
-}
-
-/// Returns the group ID for the effective user running the process.
-pub fn get_effective_gid() -> gid_t {
-    unsafe { getegid() }
-}
-
-/// Returns the groupname of the effective user running the process.
-pub fn get_effective_groupname() -> Option<String> {
-    let gid = get_effective_gid();
-    get_group_by_gid(gid).map(|g| Arc::try_unwrap(g.name_arc).unwrap())
-}
-
-
-/// An iterator over every user present on the system.
-///
-/// This struct actually requires no fields, but has one hidden one to make it
-/// `unsafe` to create.
-pub struct AllUsers(());
-
-impl AllUsers {
-
-    /// Creates a new iterator over every user present on the system.
-    ///
-    /// ## Unsafety
-    ///
-    /// This constructor is marked as `unsafe`, which is odd for a crate
-    /// that's meant to be a safe interface. It *has* to be unsafe because
-    /// we cannot guarantee that the underlying C functions,
-    /// `getpwent`/`setpwent`/`endpwent` that iterate over the system's
-    /// `passwd` entries, are called in a thread-safe manner.
-    ///
-    /// These functions [modify a global
-    /// state](http://man7.org/linux/man-pages/man3/getpwent.3.html#
-    /// ATTRIBUTES), and if any are used at the same time, the state could
-    /// be reset, resulting in a data race. We cannot even place it behind
-    /// an internal `Mutex`, as there is nothing stopping another `extern`
-    /// function definition from calling it!
-    ///
-    /// So to iterate all users, construct the iterator inside an `unsafe`
-    /// block, then make sure to not make a new instance of it until
-    /// iteration is over.
-    pub unsafe fn new() -> AllUsers {
-        setpwent();
-        AllUsers(())
-    }
-}
-
-impl Drop for AllUsers {
-    fn drop(&mut self) {
-        unsafe { endpwent() };
-    }
-}
-
-impl Iterator for AllUsers {
-    type Item = User;
-
-    fn next(&mut self) -> Option<User> {
-        unsafe { passwd_to_user(getpwent()) }
-    }
-}
-
-
 
 /// OS-specific extensions to users and groups.
 ///
@@ -468,7 +208,8 @@ pub mod os {
     pub mod unix {
         use std::path::Path;
 
-        use super::super::{c_passwd, c_group, members, from_raw_buf, Group};
+        use super::super::Group;
+        use super::super::unix::{c_passwd, c_group, members, from_raw_buf};
 
         /// Unix-specific extensions for `User`s.
         pub trait UserExt {
@@ -602,7 +343,8 @@ pub mod os {
     pub mod bsd {
         use std::path::Path;
         use libc::time_t;
-        use super::super::{c_passwd, User};
+        use super::super::User;
+        use super::super::unix::c_passwd;
 
         /// BSD-specific fields for `User`s.
         #[derive(Clone, Debug)]
@@ -682,6 +424,108 @@ pub mod os {
         }
     }
 
+
+    /// Extensions to users and groups for Redox.
+    #[cfg(target_os = "redox")]
+    pub mod redox {
+        use std::path::Path;
+
+        use super::super::Group;
+
+        /// Redox-specific extensions for `User`s.
+        pub trait UserExt {
+            /// Returns a path to this user’s home directory.
+            fn home_dir(&self) -> &Path;
+
+            /// Sets this user value’s home directory to the given string.
+            /// Can be used to construct test users, which by default come with a
+            /// dummy home directory string.
+            fn with_home_dir(self, home_dir: &str) -> Self;
+
+            /// Returns a path to this user’s shell.
+            fn shell(&self) -> &Path;
+
+            /// Sets this user’s shell path to the given string.
+            /// Can be used to construct test users, which by default come with a
+            /// dummy shell field.
+            fn with_shell(self, shell: &str) -> Self;
+
+            // TODO(ogham): Isn’t it weird that the setters take string slices, but
+            // the getters return paths?
+        }
+
+        /// Unix-specific extensions for `Group`s.
+        pub trait GroupExt {
+
+            /// Returns a slice of the list of users that are in this group as
+            /// their non-primary group.
+            fn members(&self) -> &[String];
+
+            /// Adds a new member to this group.
+            fn add_member(self, name: &str) -> Self;
+        }
+
+        /// Redox-specific fields for `User`s.
+        #[derive(Clone, Debug)]
+        pub struct UserExtras {
+            /// The path to the user’s home directory.
+            pub home_dir: String,
+
+            /// The path to the user’s shell.
+            pub shell: String,
+        }
+
+        impl Default for UserExtras {
+            fn default() -> UserExtras {
+                UserExtras {
+                    home_dir: String::from("/var/empty"),
+                    shell:    String::from("/bin/ion"),
+                }
+            }
+        }
+
+        use super::super::User;
+
+        impl UserExt for User {
+            fn home_dir(&self) -> &Path {
+                Path::new(&self.extras.home_dir)
+            }
+
+            fn with_home_dir(mut self, home_dir: &str) -> User {
+                self.extras.home_dir = home_dir.to_owned();
+                self
+            }
+
+            fn shell(&self) -> &Path {
+                Path::new(&self.extras.shell)
+            }
+
+            fn with_shell(mut self, shell: &str) -> User {
+                self.extras.shell = shell.to_owned();
+                self
+            }
+        }
+
+        /// Unix-specific fields for `Group`s.
+        #[derive(Clone, Default, Debug)]
+        pub struct GroupExtras {
+
+            /// Vector of usernames that are members of this group.
+            pub members: Vec<String>,
+        }
+
+        impl GroupExt for Group {
+            fn members(&self) -> &[String] {
+                &*self.extras.members
+            }
+
+            fn add_member(mut self, member: &str) -> Group {
+                self.extras.members.push(member.to_owned());
+                self
+            }
+        }
+    }
+
     /// Any extra fields on a `User` specific to the current platform.
     #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd"))]
     pub type UserExtras = bsd::UserExtras;
@@ -693,8 +537,15 @@ pub mod os {
     /// Any extra fields on a `Group` specific to the current platform.
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd"))]
     pub type GroupExtras = unix::GroupExtras;
-}
 
+    /// Any extra fields on a `User` specific to the current platform.
+    #[cfg(any(target_os = "redox"))]
+    pub type UserExtras = redox::UserExtras;
+
+    /// Any extra fields on a `Group` specific to the current platform.
+    #[cfg(target_os = "redox")]
+    pub type GroupExtras = redox::GroupExtras;
+}
 
 #[cfg(test)]
 mod test {
@@ -728,7 +579,11 @@ mod test {
 
     #[test]
     fn user_info() {
+        #[cfg(unix)]
         use base::os::unix::UserExt;
+
+        #[cfg(target_os = "redox")]
+        use base::os::redox::UserExt;
 
         let uid = get_current_uid();
         let user = get_user_by_uid(uid).unwrap();
@@ -768,3 +623,5 @@ mod test {
         assert!(group.is_none());
     }
 }
+
+

--- a/src/base/redox.rs
+++ b/src/base/redox.rs
@@ -1,0 +1,156 @@
+//! Integration with the Redox OS users and groups.
+//!
+
+#![allow(missing_copy_implementations)]  // for the C structs
+
+use std::sync::Arc;
+use std::convert::From;
+
+use libc::{uid_t, gid_t};
+use redox_users;
+use super::{User, Group};
+
+impl From<redox_users::User> for User {
+    fn from(redox_user: redox_users::User) -> Self {
+        User {
+            uid: redox_user.uid as uid_t,
+            name_arc: Arc::new(redox_user.user),
+            primary_group: redox_user.gid as uid_t,
+            extras: super::os::UserExtras {
+                home_dir:  redox_user.home,
+                shell: redox_user.shell
+            }
+        }
+    }
+}
+
+impl From<redox_users::Group> for Group {
+    fn from(redox_group: redox_users::Group) -> Self {
+        Group::new(redox_group.gid as gid_t, &redox_group.group)
+    }
+}
+
+/// Searches for a `User` with the given ID in the system’s user database.
+/// Returns it if one is found, otherwise returns `None`.
+pub fn get_user_by_uid(uid: uid_t) -> Option<User> {
+    match redox_users::get_user_by_id(uid) {
+        None => None,
+        Some(redox_user) => Some(User::from(redox_user))
+    }
+}
+
+/// Searches for a `User` with the given username in the system’s user database.
+/// Returns it if one is found, otherwise returns `None`.
+pub fn get_user_by_name(username: &str) -> Option<User> {
+    match redox_users::get_user_by_name(username) {
+        None => None,
+        Some(redox_user) => Some(User::from(redox_user))
+    }
+}
+
+/// Searches for a `Group` with the given ID in the system’s group database.
+/// Returns it if one is found, otherwise returns `None`.
+pub fn get_group_by_gid(gid: gid_t) -> Option<Group> {
+    match redox_users::get_group_by_id(gid) {
+        None => None,
+        Some(redox_group) => Some(Group::from(redox_group))
+    }
+}
+
+/// Searches for a `Group` with the given group name in the system’s group database.
+/// Returns it if one is found, otherwise returns `None`.
+pub fn get_group_by_name(group_name: &str) -> Option<Group> {
+    match redox_users::get_group_by_name(group_name) {
+        None => None,
+        Some(redox_group) => Some(Group::from(redox_group))
+    }
+}
+
+/// Returns the user ID for the user running the process.
+pub fn get_current_uid() -> uid_t {
+    redox_users::get_uid()
+}
+
+/// Returns the username of the user running the process.
+pub fn get_current_username() -> Option<String> {
+    let uid = get_current_uid();
+
+    redox_users::get_user_by_id(uid).map(|u| u.user)
+}
+
+/// Returns the user ID for the effective user running the process.
+pub fn get_effective_uid() -> uid_t {
+    redox_users::get_euid()
+}
+
+/// Returns the username of the effective user running the process.
+pub fn get_effective_username() -> Option<String> {
+    let uid = get_effective_uid();
+
+    redox_users::get_user_by_id(uid).map(|u| u.user)
+}
+
+/// Returns the group ID for the user running the process.
+pub fn get_current_gid() -> gid_t {
+    redox_users::get_gid()
+}
+
+/// Returns the groupname of the user running the process.
+pub fn get_current_groupname() -> Option<String> {
+    let gid = get_current_gid();
+
+    redox_users::get_group_by_id(gid).map(|g| g.group)
+}
+
+/// Returns the group ID for the effective user running the process.
+pub fn get_effective_gid() -> gid_t {
+    redox_users::get_egid()
+}
+
+/// Returns the groupname of the effective user running the process.
+pub fn get_effective_groupname() -> Option<String> {
+    let gid = get_effective_gid();
+
+    redox_users::get_group_by_id(gid).map(|g| g.group)
+}
+
+/// An iterator over every user present on the system.
+///
+/// This struct actually requires no fields, but has one hidden one to make it
+/// `unsafe` to create.
+pub struct AllUsers(redox_users::AllUsers);
+
+impl AllUsers {
+
+    /// Creates a new iterator over every user present on the system.
+    ///
+    /// ## Unsafety
+    ///
+    /// This constructor is marked as `unsafe`, which is odd for a crate
+    /// that's meant to be a safe interface. It *has* to be unsafe because
+    /// we cannot guarantee that the underlying C functions,
+    /// `getpwent`/`setpwent`/`endpwent` that iterate over the system's
+    /// `passwd` entries, are called in a thread-safe manner.
+    ///
+    /// These functions [modify a global
+    /// state](http://man7.org/linux/man-pages/man3/getpwent.3.html#
+    /// ATTRIBUTES), and if any are used at the same time, the state could
+    /// be reset, resulting in a data race. We cannot even place it behind
+    /// an internal `Mutex`, as there is nothing stopping another `extern`
+    /// function definition from calling it!
+    ///
+    /// So to iterate all users, construct the iterator inside an `unsafe`
+    /// block, then make sure to not make a new instance of it until
+    /// iteration is over.
+    pub unsafe fn new() -> AllUsers {
+        AllUsers(redox_users::all_users())
+    }
+}
+
+impl Iterator for AllUsers {
+    type Item = User;
+
+    fn next(&mut self) -> Option<User> {
+        self.0.next().map(|redox_user| User::from(redox_user))
+    }
+}

--- a/src/base/unix.rs
+++ b/src/base/unix.rs
@@ -1,0 +1,324 @@
+//! Integration with the C library’s users and groups.
+//!
+//! This module uses `extern` functions and types from `libc` that integrate
+//! with the system’s C library, which integrates with the OS itself to get user
+//! and group information. It’s where the “core” user handling is done.
+//!
+//!
+//! ## Name encoding rules
+//!
+//! Under Unix, usernames and group names are considered to be
+//! null-terminated, UTF-8 strings. These are `CString`s in Rust, although in
+//! this library, they are just `String` values. Why?
+//!
+//! The reason is that any user or group values with invalid `CString` data
+//! can instead just be assumed to not exist:
+//!
+//! - If you try to search for a user with a null character in their name,
+//!   such a user could not exist anyway—so it’s OK to return `None`.
+//! - If the OS returns user information with a null character in a field,
+//!   then that field will just be truncated instead, which is valid behaviour
+//!   for a `CString`.
+//!
+//! The downside is that we use `from_utf8_lossy` instead, which has a small
+//! runtime penalty when it calculates and scans the length of the string for
+//! invalid characters. However, this should not be a problem when dealing with
+//! usernames of a few bytes each.
+//!
+//! In short, if you want to check for null characters in user fields, your
+//! best bet is to check for them yourself before passing strings into any
+//! functions.
+
+#![allow(missing_copy_implementations)]  // for the C structs
+
+#[cfg(not(target_os = "redox"))]
+use std::ffi::{CStr, CString};
+use std::ptr::read;
+use std::sync::Arc;
+
+use super::{User, Group};
+
+use libc::{uid_t, gid_t};
+
+#[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd"))]
+use libc::{c_char, time_t};
+
+#[cfg(any(target_os = "linux"))]
+use libc::c_char;
+
+#[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd"))]
+#[repr(C)]
+pub struct c_passwd {
+    pub(crate) pw_name:    *const c_char,  // user name
+    pub(crate) pw_passwd:  *const c_char,  // password field
+    pub(crate) pw_uid:     uid_t,          // user ID
+    pub(crate) pw_gid:     gid_t,          // group ID
+    pub(crate) pw_change:  time_t,         // password change time
+    pub(crate) pw_class:   *const c_char,
+    pub(crate) pw_gecos:   *const c_char,
+    pub(crate) pw_dir:     *const c_char,  // user's home directory
+    pub(crate) pw_shell:   *const c_char,  // user's shell
+    pub(crate) pw_expire:  time_t,         // password expiry time
+}
+
+#[cfg(target_os = "linux")]
+#[repr(C)]
+pub struct c_passwd {
+    pub(crate) pw_name:    *const c_char,  // user name
+    pub(crate) pw_passwd:  *const c_char,  // password field
+    pub(crate) pw_uid:     uid_t,          // user ID
+    pub(crate) pw_gid:     gid_t,          // group ID
+    pub(crate) pw_gecos:   *const c_char,
+    pub(crate) pw_dir:     *const c_char,  // user's home directory
+    pub(crate) pw_shell:   *const c_char,  // user's shell
+}
+
+#[repr(C)]
+pub struct c_group {
+    pub(crate) gr_name:   *const c_char,         // group name
+    pub(crate) gr_passwd: *const c_char,         // password
+    pub(crate) gr_gid:    gid_t,                 // group id
+    pub(crate) gr_mem:    *const *const c_char,  // names of users in the group
+}
+
+extern {
+    fn getpwuid(uid: uid_t) -> *const c_passwd;
+    fn getpwnam(user_name: *const c_char) -> *const c_passwd;
+
+    fn getgrgid(gid: gid_t) -> *const c_group;
+    fn getgrnam(group_name: *const c_char) -> *const c_group;
+
+    fn getuid() -> uid_t;
+    fn geteuid() -> uid_t;
+
+    fn getgid() -> gid_t;
+    fn getegid() -> gid_t;
+
+    fn setpwent();
+    fn getpwent() -> *const c_passwd;
+    fn endpwent();
+}
+
+/// Reads data from a `*char` field in `c_passwd` or `g_group` into a UTF-8
+/// `String` for use in a user or group value.
+///
+/// Although `from_utf8_lossy` returns a clone-on-write string, we immediately
+/// clone it anyway: the underlying buffer is managed by the C library, not by
+/// us, so we *need* to move data out of it before the next user gets read.
+pub(crate) unsafe fn from_raw_buf(p: *const c_char) -> String {
+    CStr::from_ptr(p).to_string_lossy().into_owned()
+}
+
+/// Converts a raw pointer, which could be null, into a safe reference that
+/// might be `None` instead.
+///
+/// This is basically the unstable `ptr_as_ref` feature:
+/// https://github.com/rust-lang/rust/issues/27780
+/// When that stabilises, this can be replaced.
+pub(crate) unsafe fn ptr_as_ref<T>(pointer: *const T) -> Option<T> {
+    if pointer.is_null() {
+        None
+    }
+    else {
+        Some(read(pointer))
+    }
+}
+
+unsafe fn passwd_to_user(pointer: *const c_passwd) -> Option<User> {
+    if let Some(passwd) = ptr_as_ref(pointer) {
+        let name = Arc::new(from_raw_buf(passwd.pw_name));
+
+        Some(User {
+            uid:           passwd.pw_uid,
+            name_arc:      name,
+            primary_group: passwd.pw_gid,
+            extras:        super::os::UserExtras::from_passwd(passwd),
+        })
+    }
+    else {
+        None
+    }
+}
+
+unsafe fn struct_to_group(pointer: *const c_group) -> Option<Group> {
+    if let Some(group) = ptr_as_ref(pointer) {
+        let name = Arc::new(from_raw_buf(group.gr_name));
+
+        Some(Group {
+            gid:       group.gr_gid,
+            name_arc:  name,
+            extras:    super::os::GroupExtras::from_struct(group),
+        })
+    }
+    else {
+        None
+    }
+}
+
+/// Expand a list of group members to a vector of strings.
+///
+/// The list of members is, in true C fashion, a pointer to a pointer of
+/// characters, terminated by a null pointer. We check `members[0]`, then
+/// `members[1]`, and so on, until that null pointer is reached. It doesn't
+/// specify whether we should expect a null pointer or a pointer to a null
+/// pointer, so we check for both here!
+pub(crate) unsafe fn members(groups: *const *const c_char) -> Vec<String> {
+    let mut members = Vec::new();
+
+    for i in 0.. {
+        let username = groups.offset(i);
+
+        if username.is_null() || (*username).is_null() {
+            break;
+        }
+        else {
+            members.push(from_raw_buf(*username));
+        }
+    }
+
+    members
+}
+
+/// Searches for a `User` with the given ID in the system’s user database.
+/// Returns it if one is found, otherwise returns `None`.
+pub fn get_user_by_uid(uid: uid_t) -> Option<User> {
+    unsafe {
+        let passwd = getpwuid(uid);
+        passwd_to_user(passwd)
+    }
+}
+
+/// Searches for a `User` with the given username in the system’s user database.
+/// Returns it if one is found, otherwise returns `None`.
+pub fn get_user_by_name(username: &str) -> Option<User> {
+    if let Ok(username) = CString::new(username) {
+        unsafe {
+            let passwd = getpwnam(username.as_ptr());
+            passwd_to_user(passwd)
+        }
+    }
+    else {
+        // The username that was passed in contained a null character.
+        // This will *never* find anything, so just return `None`.
+        // (I can’t figure out a pleasant way to signal an error here)
+        None
+    }
+}
+
+/// Searches for a `Group` with the given ID in the system’s group database.
+/// Returns it if one is found, otherwise returns `None`.
+pub fn get_group_by_gid(gid: gid_t) -> Option<Group> {
+    unsafe {
+        let group = getgrgid(gid);
+        struct_to_group(group)
+    }
+}
+
+/// Searches for a `Group` with the given group name in the system’s group database.
+/// Returns it if one is found, otherwise returns `None`.
+pub fn get_group_by_name(group_name: &str) -> Option<Group> {
+    if let Ok(group_name) = CString::new(group_name) {
+        unsafe {
+            let group = getgrnam(group_name.as_ptr());
+            struct_to_group(group)
+        }
+    }
+    else {
+        // The group name that was passed in contained a null character.
+        // This will *never* find anything, so just return `None`.
+        // (I can’t figure out a pleasant way to signal an error here)
+        None
+    }
+}
+
+/// Returns the user ID for the user running the process.
+pub fn get_current_uid() -> uid_t {
+    unsafe { getuid() }
+}
+
+/// Returns the username of the user running the process.
+pub fn get_current_username() -> Option<String> {
+    let uid = get_current_uid();
+    get_user_by_uid(uid).map(|u| Arc::try_unwrap(u.name_arc).unwrap())
+}
+
+/// Returns the user ID for the effective user running the process.
+pub fn get_effective_uid() -> uid_t {
+    unsafe { geteuid() }
+}
+
+/// Returns the username of the effective user running the process.
+pub fn get_effective_username() -> Option<String> {
+    let uid = get_effective_uid();
+    get_user_by_uid(uid).map(|u| Arc::try_unwrap(u.name_arc).unwrap())
+}
+
+/// Returns the group ID for the user running the process.
+pub fn get_current_gid() -> gid_t {
+    unsafe { getgid() }
+}
+
+/// Returns the groupname of the user running the process.
+pub fn get_current_groupname() -> Option<String> {
+    let gid = get_current_gid();
+    get_group_by_gid(gid).map(|g| Arc::try_unwrap(g.name_arc).unwrap())
+}
+
+/// Returns the group ID for the effective user running the process.
+pub fn get_effective_gid() -> gid_t {
+    unsafe { getegid() }
+}
+
+/// Returns the groupname of the effective user running the process.
+pub fn get_effective_groupname() -> Option<String> {
+    let gid = get_effective_gid();
+    get_group_by_gid(gid).map(|g| Arc::try_unwrap(g.name_arc).unwrap())
+}
+
+/// An iterator over every user present on the system.
+///
+/// This struct actually requires no fields, but has one hidden one to make it
+/// `unsafe` to create.
+pub struct AllUsers(());
+
+impl AllUsers {
+
+    /// Creates a new iterator over every user present on the system.
+    ///
+    /// ## Unsafety
+    ///
+    /// This constructor is marked as `unsafe`, which is odd for a crate
+    /// that's meant to be a safe interface. It *has* to be unsafe because
+    /// we cannot guarantee that the underlying C functions,
+    /// `getpwent`/`setpwent`/`endpwent` that iterate over the system's
+    /// `passwd` entries, are called in a thread-safe manner.
+    ///
+    /// These functions [modify a global
+    /// state](http://man7.org/linux/man-pages/man3/getpwent.3.html#
+    /// ATTRIBUTES), and if any are used at the same time, the state could
+    /// be reset, resulting in a data race. We cannot even place it behind
+    /// an internal `Mutex`, as there is nothing stopping another `extern`
+    /// function definition from calling it!
+    ///
+    /// So to iterate all users, construct the iterator inside an `unsafe`
+    /// block, then make sure to not make a new instance of it until
+    /// iteration is over.
+    pub unsafe fn new() -> AllUsers {
+        setpwent();
+        AllUsers(())
+    }
+}
+
+impl Drop for AllUsers {
+    fn drop(&mut self) {
+        unsafe { endpwent() };
+    }
+}
+
+impl Iterator for AllUsers {
+    type Item = User;
+
+    fn next(&mut self) -> Option<User> {
+        unsafe { passwd_to_user(getpwent()) }
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -68,7 +68,10 @@ use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use base::{User, Group, AllUsers};
+use base::{User, Group};
+
+use AllUsers;
+
 use traits::{Users, Groups};
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,11 +109,19 @@
 #![warn(trivial_casts, trivial_numeric_casts)]
 #![warn(unused_extern_crates, unused_qualifications)]
 
+#[cfg(target_os = "redox")]
+extern crate redox_users;
+#[cfg(target_os = "redox")]
+extern crate syscall as redox_syscall;
+
 extern crate libc;
 pub use libc::{uid_t, gid_t};
 
 mod base;
-pub use base::{User, Group, os};
+
+pub use base::{User, Group};
+pub use base::os;
+
 pub use base::{get_user_by_uid, get_user_by_name};
 pub use base::{get_group_by_gid, get_group_by_name};
 pub use base::{get_current_uid, get_current_username};
@@ -121,7 +129,6 @@ pub use base::{get_effective_uid, get_effective_username};
 pub use base::{get_current_gid, get_current_groupname};
 pub use base::{get_effective_gid, get_effective_groupname};
 pub use base::AllUsers;
-
 
 pub mod cache;
 pub use cache::UsersCache;

--- a/src/switch/mod.rs
+++ b/src/switch/mod.rs
@@ -1,0 +1,28 @@
+//! Functions for switching the running process’s user or group.
+
+#[cfg(target_os = "redox")]
+pub mod redox;
+#[cfg(unix)]
+pub mod unix;
+
+#[cfg(unix)]
+pub use self::unix::*;
+#[cfg(target_os = "redox")]
+pub use self::redox::*;
+
+use libc::{uid_t, gid_t};
+
+/// Guard returned from a `switch_user_group` call.
+pub struct SwitchUserGuard {
+    uid: uid_t,
+    gid: gid_t,
+}
+
+impl Drop for SwitchUserGuard {
+    fn drop(&mut self) {
+        // Panic on error here, as failing to set values back
+        // is a possible security breach.
+        set_effective_uid(self.uid).unwrap();
+        set_effective_gid(self.gid).unwrap();
+    }
+}

--- a/src/switch/redox.rs
+++ b/src/switch/redox.rs
@@ -1,0 +1,116 @@
+
+//! Functions for switching the running process’s user or group in Redox OS.
+
+use redox_syscall;
+
+use std::io::Result as IOResult;
+use libc::{uid_t, gid_t};
+
+use base::{get_effective_uid, get_effective_gid};
+use super::SwitchUserGuard;
+
+/// Sets the **current user** for the running process to the one with the
+/// given user ID. Uses `setreuid` internally.
+///
+/// Typically, trying to switch to anyone other than the user already running
+/// the process requires root privileges.
+pub fn set_current_uid(uid: uid_t) -> IOResult<()> {
+    match redox_syscall::setreuid(uid, -1 as _) {
+         Ok(_) => Ok(()),
+         Err(n) => unreachable!("setreuid returned {}", n)
+    }
+}
+
+/// Sets the **current group** for the running process to the one with the
+/// given group ID. Uses `setregid` internally.
+///
+/// Typically, trying to switch to any group other than the group already
+/// running the process requires root privileges.
+pub fn set_current_gid(gid: gid_t) -> IOResult<()> {
+    match redox_syscall::setregid(gid, -1 as _) {
+         Ok(_) => Ok(()),
+         Err(n) => unreachable!("setregid returned {}", n)
+    }
+}
+
+/// Sets the **effective user** for the running process to the one with the
+/// given user ID. Uses `setreuid` internally.
+///
+/// Typically, trying to switch to anyone other than the user already running
+/// the process requires root privileges.
+pub fn set_effective_uid(uid: uid_t) -> IOResult<()> {
+    match redox_syscall::setreuid(-1 as _, uid) {
+         Ok(_) => Ok(()),
+         Err(n) => unreachable!("setreuid returned {}", n)
+    }
+}
+
+/// Sets the **effective group** for the running process to the one with the
+/// given group ID. Uses `setregid` internally.
+///
+/// Typically, trying to switch to any group other than the group already
+/// running the process requires root privileges.
+pub fn set_effective_gid(gid: gid_t) -> IOResult<()> {
+    match redox_syscall::setregid(-1 as _, gid) {
+         Ok(_) => Ok(()),
+         Err(n) => unreachable!("setregid returned {}", n)
+    }
+}
+
+/// Sets both the **current user** and the **effective user** for the running
+/// process to the ones with the given user IDs. Uses `setreuid` internally.
+///
+/// Typically, trying to switch to anyone other than the user already running
+/// the process requires root privileges.
+pub fn set_both_uid(ruid: uid_t, euid: uid_t) -> IOResult<()> {
+    match redox_syscall::setreuid(ruid, euid) {
+         Ok(_) => Ok(()),
+         Err(n) => unreachable!("setreuid returned {}", n)
+    }
+}
+
+/// Sets both the **current group** and the **effective group** for the
+/// running process to the ones with the given group IDs. Uses `setregid`
+/// internally.
+///
+/// Typically, trying to switch to any group other than the group already
+/// running the process requires root privileges.
+pub fn set_both_gid(rgid: gid_t, egid: gid_t) -> IOResult<()> {
+    match redox_syscall::setregid(rgid, egid) {
+         Ok(_) => Ok(()),
+         Err(n) => unreachable!("setregid returned {}", n)
+    }
+}
+
+/// Sets the **effective user** and the **effective group** for the current
+/// scope.
+///
+/// Typically, trying to switch to any user or group other than the ones already
+/// running the process requires root privileges.
+///
+/// **Use with care!** Possible security issues can happen, as Rust doesn't
+/// guarantee running the destructor! If in doubt run `drop()` method on the
+/// guard value manually!
+///
+/// ### Examples
+///
+/// ```no_run
+/// use users::switch::switch_user_group;
+///
+/// {
+///     let _guard = switch_user_group(1001, 1001);
+///     // current and effective user and group ids are 1001
+/// }
+/// // back to the old values
+/// ```
+pub fn switch_user_group(uid: uid_t, gid: gid_t) -> IOResult<SwitchUserGuard> {
+    let current_state = SwitchUserGuard {
+        uid: get_effective_uid(),
+        gid: get_effective_gid(),
+    };
+
+    set_effective_gid(gid)?;
+    set_effective_uid(uid)?;
+
+    Ok(current_state)
+}

--- a/src/switch/unix.rs
+++ b/src/switch/unix.rs
@@ -1,10 +1,10 @@
-//! Functions for switching the running process’s user or group.
+//! Functions for switching the running process’s user or group in UNIX.
 
 use std::io::{Error as IOError, Result as IOResult};
 use libc::{uid_t, gid_t, c_int};
 
 use base::{get_effective_uid, get_effective_gid};
-
+use super::SwitchUserGuard;
 
 extern {
     fn setuid(uid: uid_t) -> c_int;
@@ -94,21 +94,6 @@ pub fn set_both_gid(rgid: gid_t, egid: gid_t) -> IOResult<()> {
          0 => Ok(()),
         -1 => Err(IOError::last_os_error()),
          n => unreachable!("setregid returned {}", n)
-    }
-}
-
-/// Guard returned from a `switch_user_group` call.
-pub struct SwitchUserGuard {
-    uid: uid_t,
-    gid: gid_t,
-}
-
-impl Drop for SwitchUserGuard {
-    fn drop(&mut self) {
-        // Panic on error here, as failing to set values back
-        // is a possible security breach.
-        set_effective_uid(self.uid).unwrap();
-        set_effective_gid(self.gid).unwrap();
     }
 }
 


### PR DESCRIPTION
## Added Redox support

This commit adds support for Redox OS. Along with that it does a bit of refactoring so UNIX code and Redox code live separately and the common stuff is defined only once. Rationale being that in the first
implementation (w/o separate sub-modules I ended up with many, many conditional compilation annotations and lots of duplicate functions and methods definitions). 

I tried to preserved the original structure of the library for UNIX and preserve the same layout of the entities and the API son thing gets broken by this. This is part of the ongoing effort to support `exa`.

I'm sorry in advance. It looks like a lot of changes but is just moving code around and of course the Redox implementation.

Thanks for the work on the library it was easy to read!

## Details

- Separated UNIX and Redox implementations in a new `base` module
(previously in `base.rs`).
- Separated UNIX and Redox implementations in a new `switch` module
(previously in `switch.rs`).
- Added `redox_users` and `redox_syscall` dependencies (only on Redox
targets).
- Added public(crate) visibility to fields in `User` and `Group`.
- Implemented OS extensions for Redox.
- Implemented `From` trait from `redox_users::User` to `User`.
- Fixed imports due to changes in mod hierarchy.