### PR TITLE
Switch logging from Debug to Trace level

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ println!("The '{}' group has the ID {}", group.name(), group.gid());
 
 ## Logging
 
-The `logging` feature, which is on by default, uses the `log` crate to record all interactions with the operating system.
+The `logging` feature, which is on by default, uses the `log` crate to record all interactions with the operating system at Trace log level.
 
 
 ## Caveats

--- a/src/base.rs
+++ b/src/base.rs
@@ -40,7 +40,7 @@ use std::sync::Arc;
 #[cfg(feature = "logging")]
 extern crate log;
 #[cfg(feature = "logging")]
-use self::log::debug;
+use self::log::trace;
 
 use libc::{c_char, uid_t, gid_t, c_int};
 use libc::passwd as c_passwd;
@@ -252,7 +252,7 @@ unsafe fn from_raw_buf(p: *const c_char) -> OsString {
 /// Reads data from the `c_passwd` and returns it as a `User`.
 unsafe fn passwd_to_user(passwd: c_passwd) -> User {
     #[cfg(feature = "logging")]
-    debug!("Loading user with uid {}", passwd.pw_uid);
+    trace!("Loading user with uid {}", passwd.pw_uid);
 
     let name = Arc::new(from_raw_buf(passwd.pw_name));
 
@@ -267,7 +267,7 @@ unsafe fn passwd_to_user(passwd: c_passwd) -> User {
 /// Reads data from the `c_group` and returns it as a `Group`.
 unsafe fn struct_to_group(group: c_group) -> Group {
     #[cfg(feature = "logging")]
-    debug!("Loading group with gid {}", group.gr_gid);
+    trace!("Loading group with gid {}", group.gr_gid);
 
     let name = Arc::new(from_raw_buf(group.gr_name));
 
@@ -326,7 +326,7 @@ pub fn get_user_by_uid(uid: uid_t) -> Option<User> {
     let mut result = ptr::null_mut::<c_passwd>();
 
     #[cfg(feature = "logging")]
-    debug!("Running getpwuid_r for user #{}", uid);
+    trace!("Running getpwuid_r for user #{}", uid);
 
     unsafe {
         libc::getpwuid_r(uid, &mut passwd, buf.as_mut_ptr(), buf.len(), &mut result);
@@ -379,7 +379,7 @@ pub fn get_user_by_name<S: AsRef<OsStr> + ?Sized>(username: &S) -> Option<User> 
     let mut result = ptr::null_mut::<c_passwd>();
 
     #[cfg(feature = "logging")]
-    debug!("Running getpwnam_r for user {:?}", username.as_ref());
+    trace!("Running getpwnam_r for user {:?}", username.as_ref());
 
     unsafe {
         libc::getpwnam_r(username.as_ptr(), &mut passwd, buf.as_mut_ptr(), buf.len(), &mut result);
@@ -423,7 +423,7 @@ pub fn get_group_by_gid(gid: gid_t) -> Option<Group> {
     let mut result = ptr::null_mut::<c_group>();
 
     #[cfg(feature = "logging")]
-    debug!("Running getgruid_r for group #{}", gid);
+    trace!("Running getgruid_r for group #{}", gid);
 
     unsafe {
         libc::getgrgid_r(gid, &mut passwd, buf.as_mut_ptr(), buf.len(), &mut result);
@@ -476,7 +476,7 @@ pub fn get_group_by_name<S: AsRef<OsStr> + ?Sized>(groupname: &S) -> Option<Grou
     let mut result = ptr::null_mut::<c_group>();
 
     #[cfg(feature = "logging")]
-    debug!("Running getgrnam_r for group {:?}", groupname.as_ref());
+    trace!("Running getgrnam_r for group {:?}", groupname.as_ref());
 
     unsafe {
         libc::getgrnam_r(groupname.as_ptr(), &mut group, buf.as_mut_ptr(), buf.len(), &mut result);
@@ -512,7 +512,7 @@ pub fn get_group_by_name<S: AsRef<OsStr> + ?Sized>(groupname: &S) -> Option<Grou
 /// ```
 pub fn get_current_uid() -> uid_t {
     #[cfg(feature = "logging")]
-    debug!("Running getuid");
+    trace!("Running getuid");
 
     unsafe { libc::getuid() }
 }
@@ -557,7 +557,7 @@ pub fn get_current_username() -> Option<OsString> {
 /// ```
 pub fn get_effective_uid() -> uid_t {
     #[cfg(feature = "logging")]
-    debug!("Running geteuid");
+    trace!("Running geteuid");
 
     unsafe { libc::geteuid() }
 }
@@ -599,7 +599,7 @@ pub fn get_effective_username() -> Option<OsString> {
 /// ```
 pub fn get_current_gid() -> gid_t {
     #[cfg(feature = "logging")]
-    debug!("Running getgid");
+    trace!("Running getgid");
 
     unsafe { libc::getgid() }
 }
@@ -641,7 +641,7 @@ pub fn get_current_groupname() -> Option<OsString> {
 /// ```
 pub fn get_effective_gid() -> gid_t {
     #[cfg(feature = "logging")]
-    debug!("Running getegid");
+    trace!("Running getegid");
 
     unsafe { libc::getegid() }
 }
@@ -692,7 +692,7 @@ pub fn group_access_list() -> io::Result<Vec<Group>> {
     let mut buff: Vec<gid_t> = vec![0; 1024];
 
     #[cfg(feature = "logging")]
-    debug!("Running getgroups");
+    trace!("Running getgroups");
 
     let res = unsafe {
         libc::getgroups(1024, buff.as_mut_ptr())
@@ -736,7 +736,7 @@ pub fn get_user_groups<S: AsRef<OsStr> + ?Sized>(username: &S, gid: gid_t) -> Op
     let mut count = buff.len() as c_int;
 
     #[cfg(feature = "logging")]
-    debug!("Running getgrouplist for user {:?} and group #{}", username.as_ref(), gid);
+    trace!("Running getgrouplist for user {:?} and group #{}", username.as_ref(), gid);
 
     // MacOS uses i32 instead of gid_t in getgrouplist for unknown reasons
     #[cfg(all(unix, target_os="macos"))]
@@ -805,7 +805,7 @@ struct AllUsers;
 /// ```
 pub unsafe fn all_users() -> impl Iterator<Item=User> {
     #[cfg(feature = "logging")]
-    debug!("Running setpwent");
+    trace!("Running setpwent");
 
     #[cfg(not(target_os = "android"))]
     libc::setpwent();
@@ -821,7 +821,7 @@ impl Drop for AllUsers {
     #[cfg(not(target_os = "android"))]
     fn drop(&mut self) {
         #[cfg(feature = "logging")]
-        debug!("Running endpwent");
+        trace!("Running endpwent");
 
         unsafe { libc::endpwent() };
     }
@@ -838,7 +838,7 @@ impl Iterator for AllUsers {
     #[cfg(not(target_os = "android"))]
     fn next(&mut self) -> Option<User> {
         #[cfg(feature = "logging")]
-        debug!("Running getpwent");
+        trace!("Running getpwent");
 
         let result = unsafe { libc::getpwent() };
 


### PR DESCRIPTION
I think this sort of unconditional logging from such a general library should use the lowest possible logging level.

If these log messages were hinting something unexpected, then higher log levels would seem appropriate. What do you think?

I'm developing a CLI application and want to use the Debug level for when user asks for more verbose output (`-vv`). Of course the alternative is to disable the `logging` feature for `users`.
