### PR TITLE
Add cfg illlumos in addition to solaris

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -923,7 +923,17 @@ pub mod os {
     /// Although the `passwd` struct is common among Unix systems, its actual
     /// format can vary. See the definitions in the `base` module to check which
     /// fields are actually present.
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd", target_os = "netbsd", target_os = "solaris"))]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "solaris",
+        target_os = "illumos"
+    ))]
     pub mod unix {
         use std::ffi::{OsStr, OsString};
         use std::path::{Path, PathBuf};
@@ -1012,10 +1022,10 @@ pub mod os {
             }
         }
 
-        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris", target_os = "illumos"))]
         use super::super::User;
 
-        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris", target_os = "illumos"))]
         impl UserExt for User {
             fn home_dir(&self) -> &Path {
                 Path::new(&self.extras.home_dir)
@@ -1176,11 +1186,21 @@ pub mod os {
     pub type UserExtras = bsd::UserExtras;
 
     /// Any extra fields on a `User` specific to the current platform.
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris", target_os = "illumos"))]
     pub type UserExtras = unix::UserExtras;
 
     /// Any extra fields on a `Group` specific to the current platform.
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd", target_os = "netbsd", target_os = "solaris"))]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "solaris",
+        target_os = "illumos"
+    ))]
     pub type GroupExtras = unix::GroupExtras;
 }
 


### PR DESCRIPTION
I initially noticed this was broken when trying to install `fd-find` on OmniOS via `cargo install fd-find`.
illumos is its own distinct rust target now.  Building with rust-users on a platform such as OmniOS or SmartOS that uses the illumos target via rustup is currently broken.  Adding the proper cfg parameters fixes this.  Note I chose to ignore the lint warning as it's not related to this change.

Test output:
```
link - rustdev ~/src/rust-users (git:illumos) $ cargo t
warning: trivial numeric cast: `u32` as `u32`
   --> src/base.rs:805:46
    |
805 |             .filter_map(|i| get_group_by_gid(i as gid_t))
    |                                              ^^^^^^^^^^
    |
note: the lint level is defined here
   --> src/lib.rs:4:9
    |
4   | #![warn(trivial_numeric_casts)]
    |         ^^^^^^^^^^^^^^^^^^^^^
    = help: cast can be replaced by coercion; this might require a temporary variable

warning: `users` (lib) generated 1 warning
warning: `users` (lib test) generated 1 warning (1 duplicate)
    Finished test [unoptimized + debuginfo] target(s) in 0.01s
     Running unittests (target/debug/deps/users-3fb7ce1dfa6464a5)

running 18 tests
test base::test::uid ... ok
test base::test::username ... ok
test base::test::username_for_uid_for_username ... ok
test mock::test::gid ... ok
test mock::test::group_name ... ok
test base::test::group_by_name ... ok
test mock::test::current_username ... ok
test base::test::uid_for_username ... ok
test base::test::user_by_name ... ok
test mock::test::no_current_username ... ok
test base::test::user_info ... ok
test mock::test::no_gid ... ok
test mock::test::no_group_name ... ok
test mock::test::no_uid ... ok
test mock::test::no_username ... ok
test mock::test::uid ... ok
test base::test::user_get_groups ... ok
test mock::test::username ... ok

test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests users

running 39 tests
test src/base.rs - base::User::groups (line 135) - compile ... ok
test src/base.rs - base::get_user_groups (line 768) - compile ... ok
test src/cache.rs - cache (line 47) - compile ... ok
test src/base.rs - base::group_access_list (line 731) - compile ... ok
test src/lib.rs - (line 102) - compile ... ok
test src/cache.rs - cache (line 11) - compile ... ok
test src/switch.rs - switch::set_both_gid (line 189) - compile ... ok
test src/switch.rs - switch::set_both_uid (line 158) - compile ... ok
test src/switch.rs - switch::set_current_gid (line 65) - compile ... ok
test src/switch.rs - switch::set_current_uid (line 34) - compile ... ok
test src/switch.rs - switch::set_effective_gid (line 127) - compile ... ok
test src/switch.rs - switch::set_effective_uid (line 96) - compile ... ok
test src/switch.rs - switch::switch_user_group (line 245) - compile ... ok
test src/base.rs - base::Group::new (line 185) ... ok
test src/base.rs - base::User::new (line 71) ... ok
test src/base.rs - base::all_users (line 845) ... ok
test src/base.rs - base::User::primary_group_id (line 116) ... ok
test src/base.rs - base::Group::gid (line 201) ... ok
test src/base.rs - base::get_current_gid (line 638) ... ok
test src/base.rs - base::User::name (line 101) ... ok
test src/base.rs - base::get_effective_uid (line 594) ... ok
test src/cache.rs - cache::UsersCache::with_all_users (line 174) ... ok
test src/base.rs - base::get_current_uid (line 547) ... ok
test src/base.rs - base::Group::name (line 215) ... ok
test src/base.rs - base::User::uid (line 87) ... ok
test src/cache.rs - cache::UsersCache::new (line 155) ... ok
test src/base.rs - base::get_current_username (line 571) ... ok
test src/base.rs - base::get_group_by_gid (line 433) ... ok
test src/base.rs - base::get_effective_username (line 615) ... ok
test src/base.rs - base::get_effective_gid (line 682) ... ok
test src/base.rs - base::get_current_groupname (line 659) ... ok
test src/lib.rs - (line 77) ... ok
test src/base.rs - base::get_user_by_uid (line 318) ... ok
test src/mock.rs - mock (line 19) ... ok
test src/lib.rs - (line 43) ... ok
test src/base.rs - base::get_effective_groupname (line 703) ... ok
test src/base.rs - base::get_user_by_name (line 371) ... ok
test src/base.rs - base::get_group_by_name (line 486) ... ok
test src/mock.rs - mock (line 41) ... ok

test result: ok. 39 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.84s
```