### PR TITLE
enable solaris-supporting code for illumos

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -923,7 +923,7 @@ pub mod os {
     /// Although the `passwd` struct is common among Unix systems, its actual
     /// format can vary. See the definitions in the `base` module to check which
     /// fields are actually present.
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd", target_os = "netbsd", target_os = "solaris"))]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd", target_os = "netbsd", target_os = "solaris", target_os = "illumos"))]
     pub mod unix {
         use std::ffi::{OsStr, OsString};
         use std::path::{Path, PathBuf};
@@ -1012,10 +1012,10 @@ pub mod os {
             }
         }
 
-        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris", target_os = "illumos"))]
         use super::super::User;
 
-        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris", target_os = "illumos"))]
         impl UserExt for User {
             fn home_dir(&self) -> &Path {
                 Path::new(&self.extras.home_dir)
@@ -1176,11 +1176,11 @@ pub mod os {
     pub type UserExtras = bsd::UserExtras;
 
     /// Any extra fields on a `User` specific to the current platform.
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris", target_os = "illumos"))]
     pub type UserExtras = unix::UserExtras;
 
     /// Any extra fields on a `Group` specific to the current platform.
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd", target_os = "netbsd", target_os = "solaris"))]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd", target_os = "netbsd", target_os = "solaris", target_os = "illumos"))]
     pub type GroupExtras = unix::GroupExtras;
 }
 


### PR DESCRIPTION
this trivial change allows `fd`, `exa`, etc. to build and run on illumos targets.